### PR TITLE
Add task management endpoints

### DIFF
--- a/business_analysis/main.py
+++ b/business_analysis/main.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, redirect, url_for, jsonify
+from flask import Blueprint, render_template, request, redirect, url_for, jsonify, abort
 from flask_login import login_required, current_user
 from .models import Task
 from . import db
@@ -36,6 +36,26 @@ def add_task():
     title = request.form['title']
     task = Task(user_id=current_user.id, title=title)
     db.session.add(task)
+    db.session.commit()
+    return redirect(url_for('main.dashboard'))
+
+@main_bp.route('/toggle_task/<int:task_id>')
+@login_required
+def toggle_task(task_id):
+    task = Task.query.get_or_404(task_id)
+    if task.user_id != current_user.id:
+        abort(403)
+    task.toggle()
+    db.session.commit()
+    return redirect(url_for('main.dashboard'))
+
+@main_bp.route('/delete_task/<int:task_id>')
+@login_required
+def delete_task(task_id):
+    task = Task.query.get_or_404(task_id)
+    if task.user_id != current_user.id:
+        abort(403)
+    task.delete()
     db.session.commit()
     return redirect(url_for('main.dashboard'))
 

--- a/business_analysis/models.py
+++ b/business_analysis/models.py
@@ -16,3 +16,11 @@ class Task(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     title = db.Column(db.String(100))
     completed = db.Column(db.Boolean, default=False)
+
+    def toggle(self):
+        """Flip the completion state of the task."""
+        self.completed = not self.completed
+
+    def delete(self):
+        """Remove the task from the session."""
+        db.session.delete(self)

--- a/business_analysis/templates/dashboard.html
+++ b/business_analysis/templates/dashboard.html
@@ -7,7 +7,11 @@
 </form>
 <ul>
 {% for task in tasks %}
-    <li>{{ task.title }}</li>
+    <li>
+        {{ task.title }} - {% if task.completed %}Complete{% else %}Incomplete{% endif %}
+        <a href="{{ url_for('main.toggle_task', task_id=task.id) }}">Toggle</a>
+        <a href="{{ url_for('main.delete_task', task_id=task.id) }}">Delete</a>
+    </li>
 {% else %}
     <li>No tasks</li>
 {% endfor %}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,5 @@
 from business_analysis import create_app, db
+from business_analysis import models
 import pytest
 
 @pytest.fixture
@@ -15,3 +16,40 @@ def client(app):
 def test_index(client):
     res = client.get('/')
     assert res.status_code == 200
+
+
+def signup(client, username="user", password="pass"):
+    return client.post(
+        "/auth/signup",
+        data={"username": username, "password": password},
+        follow_redirects=True,
+    )
+
+
+def test_task_toggle_and_delete(client, app):
+    signup(client)
+
+    # Add a task
+    client.post("/add_task", data={"title": "Test"}, follow_redirects=True)
+
+    with app.app_context():
+        task = db.session.execute(db.select(models.Task)).scalars().first()
+        assert task is not None
+        task_id = task.id
+        assert task.completed is False
+
+    # Toggle completion
+    res = client.get(f"/toggle_task/{task_id}", follow_redirects=True)
+    assert res.status_code == 200
+    assert b"Complete" in res.data
+
+    with app.app_context():
+        task = models.Task.query.get(task_id)
+        assert task.completed is True
+
+    # Delete task
+    res = client.get(f"/delete_task/{task_id}", follow_redirects=True)
+    assert res.status_code == 200
+
+    with app.app_context():
+        assert models.Task.query.get(task_id) is None


### PR DESCRIPTION
## Summary
- toggle Task completion
- delete tasks
- display task status in the dashboard
- test new routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'business_analysis')*
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*

------
https://chatgpt.com/codex/tasks/task_e_684d98f78a608327a1714c5b81c4e0f9