### PR TITLE
Add project blueprint and CRUD UI

### DIFF
--- a/business_analysis/__init__.py
+++ b/business_analysis/__init__.py
@@ -27,7 +27,9 @@ def create_app(test_config=None):
 
         from .auth import auth_bp
         from .main import main_bp
+        from .project import project_bp
         app.register_blueprint(auth_bp)
         app.register_blueprint(main_bp)
+        app.register_blueprint(project_bp)
 
         return app

--- a/business_analysis/models.py
+++ b/business_analysis/models.py
@@ -11,8 +11,16 @@ class User(db.Model, UserMixin):
 def load_user(user_id):
     return User.query.get(int(user_id))
 
+class Project(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    name = db.Column(db.String(100), nullable=False)
+    description = db.Column(db.Text)
+    tasks = db.relationship('Task', backref='project', lazy=True)
+
 class Task(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    project_id = db.Column(db.Integer, db.ForeignKey('project.id'))
     title = db.Column(db.String(100))
     completed = db.Column(db.Boolean, default=False)

--- a/business_analysis/project.py
+++ b/business_analysis/project.py
@@ -1,0 +1,55 @@
+from flask import Blueprint, render_template, request, redirect, url_for
+from flask_login import login_required, current_user
+from .models import Project
+from . import db
+
+project_bp = Blueprint('projects', __name__, url_prefix='/projects')
+
+@project_bp.route('/')
+@login_required
+def list_projects():
+    projects = Project.query.filter_by(user_id=current_user.id).all()
+    return render_template('projects/list.html', projects=projects)
+
+@project_bp.route('/new', methods=['GET', 'POST'])
+@login_required
+def create():
+    if request.method == 'POST':
+        name = request.form['name']
+        description = request.form.get('description')
+        project = Project(user_id=current_user.id, name=name, description=description)
+        db.session.add(project)
+        db.session.commit()
+        return redirect(url_for('projects.list_projects'))
+    return render_template('projects/form.html', project=None)
+
+@project_bp.route('/<int:project_id>/edit', methods=['GET', 'POST'])
+@login_required
+def edit(project_id):
+    project = Project.query.get_or_404(project_id)
+    if project.user_id != current_user.id:
+        return redirect(url_for('projects.list_projects'))
+    if request.method == 'POST':
+        project.name = request.form['name']
+        project.description = request.form.get('description')
+        db.session.commit()
+        return redirect(url_for('projects.list_projects'))
+    return render_template('projects/form.html', project=project)
+
+@project_bp.route('/<int:project_id>/delete', methods=['POST'])
+@login_required
+def delete(project_id):
+    project = Project.query.get_or_404(project_id)
+    if project.user_id == current_user.id:
+        db.session.delete(project)
+        db.session.commit()
+    return redirect(url_for('projects.list_projects'))
+
+@project_bp.route('/<int:project_id>')
+@login_required
+def detail(project_id):
+    project = Project.query.get_or_404(project_id)
+    if project.user_id != current_user.id:
+        return redirect(url_for('projects.list_projects'))
+    tab = request.args.get('tab', 'overview')
+    return render_template('projects/detail.html', project=project, tab=tab)

--- a/business_analysis/templates/base.html
+++ b/business_analysis/templates/base.html
@@ -5,7 +5,10 @@
 </head>
 <body>
     {% if current_user.is_authenticated %}
-    Logged in as {{ current_user.username }} | <a href="{{ url_for('auth.logout') }}">Logout</a>
+    Logged in as {{ current_user.username }} |
+    <a href="{{ url_for('main.dashboard') }}">Dashboard</a> |
+    <a href="{{ url_for('projects.list_projects') }}">Projects</a> |
+    <a href="{{ url_for('auth.logout') }}">Logout</a>
     {% endif %}
     <hr>
     {% block content %}{% endblock %}

--- a/business_analysis/templates/projects/detail.html
+++ b/business_analysis/templates/projects/detail.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ project.name }}</h2>
+<ul>
+    <li><a href="{{ url_for('projects.detail', project_id=project.id, tab='overview') }}">Overview</a></li>
+    <li><a href="{{ url_for('projects.detail', project_id=project.id, tab='documents') }}">Documents</a></li>
+    <li><a href="{{ url_for('projects.detail', project_id=project.id, tab='tasks') }}">Tasks</a></li>
+    <li><a href="{{ url_for('projects.detail', project_id=project.id, tab='comm') }}">Communication Logs</a></li>
+    <li><a href="{{ url_for('projects.detail', project_id=project.id, tab='analytics') }}">Analytics</a></li>
+</ul>
+{% if tab == 'overview' %}
+<p>{{ project.description or 'No description' }}</p>
+{% elif tab == 'documents' %}
+<p>Documents placeholder</p>
+{% elif tab == 'tasks' %}
+<p>Tasks placeholder</p>
+{% elif tab == 'comm' %}
+<p>Communication logs placeholder</p>
+{% else %}
+<p>Analytics placeholder</p>
+{% endif %}
+<a href="{{ url_for('projects.list_projects') }}">Back to Projects</a>
+{% endblock %}

--- a/business_analysis/templates/projects/form.html
+++ b/business_analysis/templates/projects/form.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ 'Edit' if project else 'New' }} Project</h2>
+<form method="post">
+    <input name="name" placeholder="Name" value="{{ project.name if project else '' }}" required>
+    <br>
+    <textarea name="description" placeholder="Description">{{ project.description if project else '' }}</textarea>
+    <br>
+    <button type="submit">Save</button>
+</form>
+<a href="{{ url_for('projects.list_projects') }}">Back to Projects</a>
+{% endblock %}

--- a/business_analysis/templates/projects/list.html
+++ b/business_analysis/templates/projects/list.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Projects</h2>
+<a href="{{ url_for('projects.create') }}">New Project</a>
+<ul>
+{% for p in projects %}
+    <li>
+        <a href="{{ url_for('projects.detail', project_id=p.id) }}">{{ p.name }}</a>
+        [<a href="{{ url_for('projects.edit', project_id=p.id) }}">Edit</a>]
+        <form method="post" action="{{ url_for('projects.delete', project_id=p.id) }}" style="display:inline;">
+            <button type="submit">Delete</button>
+        </form>
+    </li>
+{% else %}
+    <li>No projects</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('main.dashboard') }}">Back to Dashboard</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `Project` model for user projects
- register new `projects` blueprint
- add project CRUD routes
- create simple project templates with tabs
- expose projects link in base navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684d990717848327b374bbe29702b6e8